### PR TITLE
Fix typos

### DIFF
--- a/lib/ex_term/console/helpers.ex
+++ b/lib/ex_term/console/helpers.ex
@@ -130,7 +130,7 @@ defmodule ExTerm.Console.Helpers do
   @doc """
   creates a function that is tagged as an access function.
 
-  If the application evironment variable `:exterm, :check_transaction` is set,
+  If the application environment variable `:exterm, :check_transaction` is set,
   and the function is not inside of a transaction, it will raise with an error.
 
   If you're developing exterm backends, you should have this environment

--- a/lib/ex_term/console/update.ex
+++ b/lib/ex_term/console/update.ex
@@ -189,7 +189,7 @@ defmodule ExTerm.Console.Update do
   To be used when tracking update changes in a custom fashion bypassing updates
   separate from the process dictionary.
 
-  Should always be suceeded by `merge/2`, which will merge these separate updates
+  Should always be succeeded by `merge/2`, which will merge these separate updates
   into the process dictionary
   """
   def merge_changes(update, change) when is_tuple(change) do

--- a/lib/ex_term/io_server.ex
+++ b/lib/ex_term/io_server.ex
@@ -130,7 +130,7 @@ defmodule ExTerm.IOServer do
   end
 
   def marshal(_module, {:requests, []}, from, state, _) do
-    # this is only callable if the requests list is empty, which should not happpen.
+    # this is only callable if the requests list is empty, which should not happen.
     reply(from, {:error, :request})
     {:noreply, state}
   end

--- a/test/ex_term/console/_update_test.exs
+++ b/test/ex_term/console/_update_test.exs
@@ -488,7 +488,7 @@ defmodule ExTermTest.Console.UpdateTest do
     end
   end
 
-  describe "the augment_cell_change/2 function can merge succesive content" do
+  describe "the augment_cell_change/2 function can merge successive content" do
     test "location, location, location" do
       assert [{{1, 1}, {1, 3}}] === augment_cell_change([{1, 3}, {1, 1}], {1, 2})
     end

--- a/test/ex_term/style_test.exs
+++ b/test/ex_term/style_test.exs
@@ -109,7 +109,7 @@ defmodule ExTermTest.StyleTest do
     end
   end
 
-  describe "defauts:" do
+  describe "defaults:" do
     @default_color IO.ANSI.default_color() <> "text"
     test "default color works" do
       empty_css = %Style{}


### PR DESCRIPTION
Found via `codespell -S deps,_build`